### PR TITLE
Enable JDK11 in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,9 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useAci: true)
+buildPlugin(useAci: true,
+            configurations: [
+                            [platform: 'linux', jdk: '8'],
+                            [platform: 'linux', jdk: '11'],
+                            [platform: 'windows', jdk: '11'],
+            ])


### PR DESCRIPTION
Hello :wave: 

Here is a simple PR enabling JDK11 in the Jenkinsfile of this plugin, helping the global support of Java 11 in Jenkins plugins.

Please let me know if anything needs to be updated or if I missed something. Thanks a lot!

On my side, I validated that compilation + tests were running fine with JDK11. I could not validate the execution on Jenkins though, hence just modifying the Jenkins file and following the CI execution here.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
