### PR TITLE
Switch from deprecated `useAci` syntax to `useContainerAgent`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useAci: true)
+buildPlugin(useContainerAgent: true)


### PR DESCRIPTION
This is an automatic pull request, that switches from the deprecated `useAci` syntax to `useContainerAgent`.

Switching to the new syntax is a drop-in replacement and requires no further work from your side.
Once you merge this PR, you address the warning currently emitted on all builds in this repository:
![](https://i.imgur.com/8uCZKKC.png)

In case of questions, please ping me, `@NotMyFault`.

Additional information:

- [Click here to read more about the deprecated syntax](https://github.com/jenkins-infra/pipeline-library/#optional-arguments)

cc @jenkinsci/caffeine-api-plugin-developers 