### PR TITLE
Update jenkins core and build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,11 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useContainerAgent: true)
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [ platform: 'linux', jdk: '11' ],
+    [ platform: 'linux', jdk: '17' ],
+    [ platform: 'windows', jdk: '11' ],
+  ]
+ )

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <revision>2.9.3</revision>
     <changelist>0-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
   </properties>
 
   <licenses>
@@ -58,7 +58,6 @@
     </dependency>
   </dependencies>
 
-
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -71,5 +70,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.51</version>
+    <version>4.61</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This updates the Jenkins version required and update the JDK used to build the plugin. 
Since 2.361.x, Jenkins requires a JDK 11 minimun. 

I didn't use a more recent Jenkins version because it is not required and it keeps the plugin open to more users.

Closes #77.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
