### PR TITLE
Use CODEOWNERS instead of dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  reviewers:
-  - "@jenkinsci/caffeine-api-plugin-developers"
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
## Use CODEOWNERS instead of dependabot reviewers

Dependabot is now posting this comment as a warning:

> The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see this [blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)

Resolve that warning by relying on the CODEOWNERS file.

### Testing done

None.  Rely on dependabot syntax checker.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
